### PR TITLE
Refactor: Simplify session UID mapping in Track model

### DIFF
--- a/lib/core/models/agenda.dart
+++ b/lib/core/models/agenda.dart
@@ -88,7 +88,7 @@ class Track extends GitHubModel {
       name: json['name'],
       color: json['color'],
       sessionUids: (json['sessions'] as List)
-          .map((sessionUid) => sessionUid["UID"].toString())
+          .map((sessionUid) => sessionUid.toString())
           .toList(),
       // resolvedSessions will be populated by DataLoader
     );


### PR DESCRIPTION
This commit updates the `fromJson` factory constructor in the `Track` class within `lib/core/models/agenda.dart`.

The change simplifies the mapping of `sessionUids` by directly converting each item in the `json['sessions']` list to a string, instead of accessing a nested "UID" field.

- In `lib/core/models/agenda.dart`:
    - Modified the `sessionUids` mapping in `Track.fromJson` from `(json['sessions'] as List).map((sessionUid) => sessionUid["UID"].toString()).toList()` to `(json['sessions'] as List).map((sessionUid) => sessionUid.toString()).toList()`.